### PR TITLE
Allow file name to be a `pathlib.Path`

### DIFF
--- a/xroms/xroms.py
+++ b/xroms/xroms.py
@@ -7,6 +7,7 @@ import warnings
 
 import cf_xarray
 import numpy as np
+import pathlib
 import xarray as xr
 import xgcm
 
@@ -738,8 +739,10 @@ def open_netcdf(
     >>> ds = xroms.open_netcdf(file)
     """
 
-    words = "Model location should be given as string. If have list of multiple locations, use `open_mfdataset`."
+    words = ("Model location should be given as string or `pathlib.Path`."
+             "If you have list of multiple locations, use `open_mfdataset`.")
     assert isinstance(file, str), words
+    assert isinstance(file, pathlib.Path), words
 
     ds = xr.open_dataset(file, chunks=chunks, **xrargs)
 

--- a/xroms/xroms.py
+++ b/xroms/xroms.py
@@ -741,8 +741,7 @@ def open_netcdf(
 
     words = ("Model location should be given as string or `pathlib.Path`."
              "If you have list of multiple locations, use `open_mfdataset`.")
-    assert isinstance(file, str), words
-    assert isinstance(file, pathlib.Path), words
+    assert isinstance(file, (str, pathlib.Path)), words
 
     ds = xr.open_dataset(file, chunks=chunks, **xrargs)
 


### PR DESCRIPTION
The [`pathlib` module](https://docs.python.org/3/library/pathlib.html) makes it convenient to handle file names and paths. `xarray` supports [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) objects in its various functions to open and save files. By allowing file names to be either a string or `pathlib.Path`, this functionality becomes readily available in `xroms`.