### PR TITLE
a bunch of fixes and breaking changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,24 +20,19 @@ repos:
     - id: file-contents-sorter
       files: requirements-dev.txt
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.7.9
   hooks:
     - id: flake8
       exclude: docs/source/conf.py
       args: [--max-line-length=105, --ignore=E203,E501,W503, --select=select=C,E,F,W,B,B950]
 
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
   hooks:
-  - id: isort
-    additional_dependencies: [toml]
-    args: [--project=xroms, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
-
-# - repo: https://github.com/asottile/seed-isort-config
-#   rev: v2.1.1
-#   hooks:
-#     - id: seed-isort-config
+    - id: isort
+      name: isort (python)
+      args: ["--profile", "black", "--filter-files", "--lines-after-imports=2", "--project=gcm_filters", "--multi-line=3", "--lines-between-types=1", "--trailing-comma", "--force-grid-wrap=0", "--use-parentheses", "--line-width=88"]
 
 - repo: https://github.com/psf/black
   rev: 22.3.0

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ You need to have `conda` installed for these installation instructions. You'll h
 
 ### Create environment if needed
 
-As a first step, you can create an environment for this package with conda if you want. If you do this, you'll need to git clone the package first as below.
+As a first step, you can create an environment for this package with conda if you want. If you do this, you'll need to git clone the package first as below. Note that `mamba` and `conda` can be used interchangably, but `mamba` is faster for installation.
 
-    conda create --name XROMS python=3.8 --file requirements.txt
+    mamba create --name XROMS --file requirements.txt
 
 ### Install `xroms`
 
@@ -65,7 +65,7 @@ You can choose to install with conda the optional dependencies for full function
 
 and to install optional dependency `xcmocean`:
 
-    pip install git+git://github.com/kthyng/xcmocean
+    pip install git+git://github.com/xoceanmodel/xcmocean
 
 Then choose one of the following to install `xroms` from GitHub:
 
@@ -80,7 +80,7 @@ Then choose one of the following to install `xroms` from GitHub:
 1. Directly install `xroms` from github
 
     ```
-    pip install git+git://github.com/hetland/xroms
+    pip install git+git://github.com/xoceanmodel/xroms
     ```
 
 ### Optional additional installation for horizontal interpolation

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You need to have `conda` installed for these installation instructions. You'll h
 
 ### Create environment if needed
 
-As a first step, you can create an environment for this package with conda if you want. If you do this, you'll need to git clone the package first as below. Note that `mamba` and `conda` can be used interchangably, but `mamba` is faster for installation.
+As a first step, you can create an environment for this package with conda if you want. If you do this, you'll need to git clone the package first as below. Note that `mamba` and `conda` can be used interchangeably, but `mamba` is faster for installation.
 
     mamba create --name XROMS --file requirements.txt
 

--- a/xroms/__init__.py
+++ b/xroms/__init__.py
@@ -40,7 +40,6 @@ from .utilities import (
 from .xroms import open_mfnetcdf, open_netcdf, open_zarr, roms_dataset
 
 
-
 try:
     __version__ = version("xroms")
 except PackageNotFoundError:

--- a/xroms/__init__.py
+++ b/xroms/__init__.py
@@ -1,6 +1,6 @@
 """Initialize xroms."""
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 import xroms.accessor
 
@@ -40,16 +40,12 @@ from .utilities import (
 from .xroms import open_mfnetcdf, open_netcdf, open_zarr, roms_dataset
 
 
-try:
-    __version__ = get_distribution("xroms").version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = "unknown"
 
-# try:
-#     from ._version import __version__
-# except ImportError:
-#     __version__ = "unknown"
+try:
+    __version__ = version("xroms")
+except PackageNotFoundError:
+    # package is not installed
+    pass
 
 # to manage whether xesmf is installed or not
 try:

--- a/xroms/accessor.py
+++ b/xroms/accessor.py
@@ -29,13 +29,13 @@ class xromsDatasetAccessor:
         # extra for getting coordinates but changes variables
         self._ds = ds.copy(deep=True)
 
-            # self.ds, grid = xroms.roms_dataset(self.ds)
-    
+        # self.ds, grid = xroms.roms_dataset(self.ds)
+
     def set_grid(self, grid):
         """If you already have a grid object and don't want to rerun
-        
+
         Or, you want to have more options in the grid setup, input it to the xroms accessor this way.
-        
+
         Examples
         --------
         >>> ds.xroms.set_grid(grid)
@@ -435,7 +435,9 @@ class xromsDatasetAccessor:
         >>> ds.xroms.mld(thresh=0.03).isel(ocean_time=0).plot(vmin=-20, vmax=0)
         """
 
-        return xroms.mld(self.sig0, self.grid, self.ds.h, self.ds.mask_rho, thresh=thresh)
+        return xroms.mld(
+            self.sig0, self.grid, self.ds.h, self.ds.mask_rho, thresh=thresh
+        )
 
     def ddxi(
         self,
@@ -937,8 +939,10 @@ class xromsDataArrayAccessor:
         -------------
         >>> ds.salt.xroms.to_grid(grid, hcoord='rho', scoord='w')
         """
-        
-        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
+
+        raise KeyError(
+            "Other coordinates are not available on DataArray, so this transformation is only possible on Dataset."
+        )
 
         var = xroms.to_grid(
             self.da,
@@ -1025,8 +1029,10 @@ class xromsDataArrayAccessor:
         -------------
         >>> ds.salt.xroms.ddz(grid)
         """
-        
-        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
+
+        raise KeyError(
+            "Other coordinates are not available on DataArray, so this transformation is only possible on Dataset."
+        )
 
         var = xroms.ddz(
             self.da,
@@ -1125,7 +1131,9 @@ class xromsDataArrayAccessor:
         >>> ds.salt.xroms.ddxi(grid)
         """
 
-        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
+        raise KeyError(
+            "Other coordinates are not available on DataArray, so this transformation is only possible on Dataset."
+        )
 
         var = xroms.ddxi(
             self.da,
@@ -1224,7 +1232,9 @@ class xromsDataArrayAccessor:
         >>> ds.salt.xroms.ddeta(grid)
         """
 
-        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
+        raise KeyError(
+            "Other coordinates are not available on DataArray, so this transformation is only possible on Dataset."
+        )
 
         var = xroms.ddeta(
             self.da,

--- a/xroms/accessor.py
+++ b/xroms/accessor.py
@@ -29,10 +29,25 @@ class xromsDatasetAccessor:
         # extra for getting coordinates but changes variables
         self._ds = ds.copy(deep=True)
 
-        # if ds wasn't read in with an xroms load function, it probably doesn't have a grid object
-        if "grid" not in ds.attrs:
+            # self.ds, grid = xroms.roms_dataset(self.ds)
+    
+    def set_grid(self, grid):
+        """If you already have a grid object and don't want to rerun
+        
+        Or, you want to have more options in the grid setup, input it to the xroms accessor this way.
+        
+        Examples
+        --------
+        >>> ds.xroms.set_grid(grid)
+        """
+        self._grid = grid
+
+    @property
+    def grid(self):
+        if not hasattr(self, "_grid"):
             self.ds, grid = xroms.roms_dataset(self.ds)
-            self.grid = grid
+            self._grid = grid
+        return self._grid
 
     @property
     def speed(self):
@@ -420,7 +435,7 @@ class xromsDatasetAccessor:
         >>> ds.xroms.mld(thresh=0.03).isel(ocean_time=0).plot(vmin=-20, vmax=0)
         """
 
-        return xroms.mld(self.sig0, self.ds.h, self.ds.mask_rho, thresh=thresh)
+        return xroms.mld(self.sig0, self.grid, self.ds.h, self.ds.mask_rho, thresh=thresh)
 
     def ddxi(
         self,
@@ -850,12 +865,13 @@ class xromsDataArrayAccessor:
 
         self.da = da
 
-        # make copy of ds that I can use to stash DataArrays to
-        # retrieve coords without changing original ds.
-        self.ds = self.da.attrs["grid"]._ds.copy(deep=True)
+        # # make copy of ds that I can use to stash DataArrays to
+        # # retrieve coords without changing original ds.
+        # self.ds = self.da.attrs["grid"]._ds.copy(deep=True)
 
     def to_grid(
         self,
+        grid,
         hcoord=None,
         scoord=None,
         hboundary="extend",
@@ -867,6 +883,8 @@ class xromsDataArrayAccessor:
 
         Inputs
         ------
+        grid:
+            xgcm grid
         hcoord: string, optional.
             Name of horizontal grid to interpolate output to.
             Options are 'rho', 'psi', 'u', 'v'.
@@ -917,12 +935,14 @@ class xromsDataArrayAccessor:
 
         Example usage
         -------------
-        >>> ds.salt.xroms.to_grid(hcoord='rho', scoord='w')
+        >>> ds.salt.xroms.to_grid(grid, hcoord='rho', scoord='w')
         """
+        
+        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
 
         var = xroms.to_grid(
             self.da,
-            self.da.attrs["grid"],
+            grid,
             hcoord=hcoord,
             scoord=scoord,
             hboundary=hboundary,
@@ -935,6 +955,7 @@ class xromsDataArrayAccessor:
 
     def ddz(
         self,
+        grid,
         hcoord=None,
         scoord=None,
         hboundary="extend",
@@ -945,6 +966,8 @@ class xromsDataArrayAccessor:
     ):
         """Calculate d/dz for a variable.
 
+        grid
+            xgcm grid
         hcoord: string, optional.
             Name of horizontal grid to interpolate output to.
             Options are 'rho', 'psi', 'u', 'v'.
@@ -1000,12 +1023,14 @@ class xromsDataArrayAccessor:
 
         Example usage
         -------------
-        >>> ds.salt.xroms.ddz()
+        >>> ds.salt.xroms.ddz(grid)
         """
+        
+        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
 
         var = xroms.ddz(
             self.da,
-            self.da.attrs["grid"],
+            grid,
             hcoord=hcoord,
             scoord=scoord,
             hboundary=hboundary,
@@ -1019,6 +1044,7 @@ class xromsDataArrayAccessor:
 
     def ddxi(
         self,
+        grid,
         hcoord=None,
         scoord=None,
         hboundary="extend",
@@ -1031,6 +1057,8 @@ class xromsDataArrayAccessor:
 
         Inputs
         ------
+        grid
+            xgcm grid
         hcoord: string, optional.
             Name of horizontal grid to interpolate output to.
             Options are 'rho', 'psi', 'u', 'v'.
@@ -1094,12 +1122,14 @@ class xromsDataArrayAccessor:
 
         Example usage
         -------------
-        >>> ds.salt.xroms.ddxi()
+        >>> ds.salt.xroms.ddxi(grid)
         """
+
+        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
 
         var = xroms.ddxi(
             self.da,
-            self.da.attrs["grid"],
+            grid,
             attrs=attrs,
             hcoord=hcoord,
             scoord=scoord,
@@ -1113,6 +1143,7 @@ class xromsDataArrayAccessor:
 
     def ddeta(
         self,
+        grid,
         hcoord=None,
         scoord=None,
         hboundary="extend",
@@ -1125,6 +1156,8 @@ class xromsDataArrayAccessor:
 
         Inputs
         ------
+        grid
+            xgcm grid
         hcoord: string, optional.
             Name of horizontal grid to interpolate output to.
             Options are 'rho', 'psi', 'u', 'v'.
@@ -1188,12 +1221,14 @@ class xromsDataArrayAccessor:
 
         Example usage
         -------------
-        >>> ds.salt.xroms.ddeta()
+        >>> ds.salt.xroms.ddeta(grid)
         """
+
+        raise KeyError("Other coordinates are not available on DataArray, so this transformation is only possible on Dataset.")
 
         var = xroms.ddeta(
             self.da,
-            self.da.attrs["grid"],
+            grid,
             attrs=attrs,
             hcoord=hcoord,
             scoord=scoord,
@@ -1265,11 +1300,13 @@ class xromsDataArrayAccessor:
             self.da, self.da.cf["longitude"], self.da.cf["latitude"], lon0, lat0
         )
 
-    def gridmean(self, dim):
+    def gridmean(self, grid, dim):
         """Calculate mean accounting for variable spatial grid.
 
         Inputs
         ------
+        grid
+            xgcm grid
         dim: str, list, tuple
             Spatial dimension names to average over. In the `xgcm`
             convention, the allowable names are 'Z', 'Y', or 'X'.
@@ -1287,18 +1324,20 @@ class xromsDataArrayAccessor:
         Example usage
         -------------
         Note that the following two approaches are equivalent:
-        >>> app1 = ds.u.xroms.gridmean(('Y','X'))
+        >>> app1 = ds.u.xroms.gridmean(grid, ('Y','X'))
         >>> app2 = (ds.u*ds.dy_u*ds.dx_u).sum(('eta_rho','xi_u'))/(ds.dy_u*ds.dx_u).sum(('eta_rho','xi_u'))
         >>> np.allclose(app1, app2)
         """
 
-        return xroms.gridmean(self.da, self.da.attrs["grid"], dim)
+        return xroms.gridmean(self.da, grid, dim)
 
-    def gridsum(self, dim):
+    def gridsum(self, grid, dim):
         """Calculate sum accounting for variable spatial grid.
 
         Inputs
         ------
+        grid
+            xgcm grid
         dim: str, list, tuple
             Spatial dimension names to sum over. In the `xgcm`
             convention, the allowable names are 'Z', 'Y', or 'X'.
@@ -1316,12 +1355,12 @@ class xromsDataArrayAccessor:
         Example usage
         -------------
         Note that the following two approaches are equivalent:
-        >>> app1 = ds.u.xroms.gridsum(('Z','X'))
+        >>> app1 = ds.u.xroms.gridsum(grid, ('Z','X'))
         >>> app2 = (ds.u*ds.dz_u * ds.dx_u).sum(('s_rho','xi_u'))
         >>> np.allclose(app1, app2)
         """
 
-        return xroms.gridsum(self.da, self.da.attrs["grid"], dim)
+        return xroms.gridsum(self.da, grid, dim)
 
     def interpll(self, lons, lats, which="pairs"):
         """Interpolate var to lons/lats positions.
@@ -1365,7 +1404,7 @@ class xromsDataArrayAccessor:
 
         return xroms.interpll(self.da, lons, lats, which=which)
 
-    def isoslice(self, iso_values, iso_array=None, axis="Z"):
+    def isoslice(self, grid, iso_values, iso_array=None, axis="Z"):
         """Interpolate var to iso_values.
 
         This wraps `xgcm` `transform` function for slice interpolation,
@@ -1373,6 +1412,8 @@ class xromsDataArrayAccessor:
 
         Inputs
         ------
+        grid
+            xgcm grid
         iso_values: list, ndarray
             Values to interpolate to. If calculating var at fixed depths,
             iso_values are the fixed depths, which should be negative if
@@ -1402,25 +1443,25 @@ class xromsDataArrayAccessor:
         Example usage
         -------------
         To calculate temperature onto fixed depths:
-        >>> xroms.isoslice(ds.temp, np.linspace(0, -30, 50))
+        >>> xroms.isoslice(ds.temp, np.linspace(0, -30, 50), grid)
 
         To calculate temperature onto salinity:
-        >>> xroms.isoslice(ds.temp, np.arange(0, 36), iso_array=ds.salt, axis='Z')
+        >>> xroms.isoslice(ds.temp, np.arange(0, 36), grid, iso_array=ds.salt, axis='Z')
 
         Calculate lat-z slice of salinity along a constant longitude value (-91.5):
-        >>> xroms.isoslice(ds.salt, -91.5, iso_array=ds.lon_rho, axis='X')
+        >>> xroms.isoslice(ds.salt, -91.5, grid, iso_array=ds.lon_rho, axis='X')
 
         Calculate slice of salt at 28 deg latitude
-        >>> xroms.isoslice(ds.salt, 28, iso_array=ds.lat_rho, axis='Y')
+        >>> xroms.isoslice(ds.salt, 28, grid, iso_array=ds.lat_rho, axis='Y')
 
         Interpolate temp to salinity values between 0 and 36 in the X direction
-        >>> xroms.isoslice(ds.temp, np.linspace(0, 36, 50), iso_array=ds.salt, axis='X')
+        >>> xroms.isoslice(ds.temp, np.linspace(0, 36, 50), grid, iso_array=ds.salt, axis='X')
 
         Interpolate temp to salinity values between 0 and 36 in the Z direction
-        >>> xroms.isoslice(ds.temp, np.linspace(0, 36, 50), iso_array=ds.salt, axis='Z')
+        >>> xroms.isoslice(ds.temp, np.linspace(0, 36, 50), grid, iso_array=ds.salt, axis='Z')
 
         Calculate the depth of a specific isohaline (33):
-        >>> xroms.isoslice(ds.salt, 33, iso_array=ds.z_rho, axis='Z')
+        >>> xroms.isoslice(ds.salt, 33, grid, iso_array=ds.z_rho, axis='Z')
 
         Calculate dye 10 meters above seabed. Either do this on the vertical
         rho grid, or first change to the w grid and then use `isoslice`. You may prefer
@@ -1429,19 +1470,19 @@ class xromsDataArrayAccessor:
         * on rho grid directly:
         >>> height_from_seabed = ds.z_rho + ds.h
         >>> height_from_seabed.name = 'z_rho'
-        >>> xroms.isoslice(ds.dye_01, 10, iso_array=height_from_seabed, axis='Z')
+        >>> xroms.isoslice(ds.dye_01, 10, grid, iso_array=height_from_seabed, axis='Z')
         * on w grid:
-        >>> var_w = ds.dye_01.xroms.to_grid(scoord='w').chunk({'s_w': -1})
+        >>> var_w = ds.dye_01.xroms.to_grid(grid, scoord='w').chunk({'s_w': -1})
         >>> ds['dye_01_w'] = var_w  # currently this is the easiest way to reattached coords xgcm variables
         >>> height_from_seabed = ds.z_w + ds.h
         >>> height_from_seabed.name = 'z_w'
-        >>> xroms.isoslice(ds['dye_01_w'], 10, iso_array=height_from_seabed, axis='Z')
+        >>> xroms.isoslice(ds['dye_01_w'], 10, grid, iso_array=height_from_seabed, axis='Z')
         """
 
         return xroms.isoslice(
             self.da,
             iso_values,
-            grid=self.da.attrs["grid"],
+            grid=grid,
             iso_array=iso_array,
             axis=axis,
         )

--- a/xroms/interp.py
+++ b/xroms/interp.py
@@ -129,7 +129,7 @@ def interpll(var, lons, lats, which="pairs"):
     return varint
 
 
-def isoslice(var, iso_values, grid=None, iso_array=None, axis="Z"):
+def isoslice(var, iso_values, grid, iso_array=None, axis="Z"):
     """Interpolate var to iso_values.
 
     This wraps `xgcm` `transform` function for slice interpolation,
@@ -144,8 +144,7 @@ def isoslice(var, iso_values, grid=None, iso_array=None, axis="Z"):
         iso_values are the fixed depths, which should be negative if
         below mean sea level. If input as array, should be 1D.
     grid: xgcm.grid, optional
-        Grid object associated with var. Optional because checks var
-        attributes for grid.
+        Grid object associated with var.
     iso_array: DataArray, optional
         Array that var is interpolated onto (e.g., z coordinates or
         density). If calculating var on fixed depth slices, iso_array

--- a/xroms/roms_seawater.py
+++ b/xroms/roms_seawater.py
@@ -377,13 +377,15 @@ def M2(
     return var
 
 
-def mld(sig0, h, mask, z=None, thresh=0.03):
+def mld(sig0, grid, h, mask, z=None, thresh=0.03):
     """Calculate the mixed layer depth [m].
 
     Inputs
     ------
     sig0: DataArray
         Potential density [kg/m^3]
+    grid
+        xgcm grid
     h: DataArray, ndarray
         Depths [m].
     mask: DataArray, ndarray
@@ -430,8 +432,8 @@ def mld(sig0, h, mask, z=None, thresh=0.03):
     # the mixed layer depth is the isosurface of depth where the potential density equals the surface - a threshold
     mld = xroms.isoslice(
         z,
-        0.0,
-        sig0.attrs["grid"],
+        np.array([0.0]),
+        grid,
         iso_array=sig0 - sig0.isel(s_rho=-1) - thresh,
         axis="Z",
     )
@@ -444,8 +446,6 @@ def mld(sig0, h, mask, z=None, thresh=0.03):
     mld.attrs["name"] = "mld"
     mld.attrs["long_name"] = "mixed layer depth"
     mld.attrs["units"] = "m"
-    if "grid" in sig0.attrs:
-        mld.attrs["grid"] = sig0.attrs["grid"]
     mld.name = mld.attrs["name"]
 
     return mld.squeeze()

--- a/xroms/tests/test_accessor.py
+++ b/xroms/tests/test_accessor.py
@@ -441,7 +441,6 @@ def test_ddeta():
         coords = coord_dict[hcoord][scoord]
         coordnames = coordnamesTZYX
 
-
         acc = ds.xroms.ddeta(testvar)
         assert np.allclose(acc, xroms.ddeta(ds[testvar], grid))
         assert acc.name == acc.attrs["name"]
@@ -464,7 +463,7 @@ def test_ddz():
         # correct dim and coord in derivative direction
         # import pdb; pdb.set_trace()
         if grid._get_dims_from_axis(ds[testvar], "Z")[0] == "s_rho":
-        # if grid.axes["Z"]._get_axis_coord(ds[testvar])[1] == "s_rho":
+            # if grid.axes["Z"]._get_axis_coord(ds[testvar])[1] == "s_rho":
             dims[1] = "s_w"
             coords[1] = coords[1].replace("rho", "w")
         else:

--- a/xroms/tests/test_accessor.py
+++ b/xroms/tests/test_accessor.py
@@ -291,7 +291,7 @@ def test_rho():
     acc = ds.xroms.rho
     assert np.allclose(acc, xroms.density(ds.temp, ds.salt, ds.z_rho))
     assert acc.name == acc.attrs["name"]
-    assert isinstance(acc.attrs["grid"], xgrid.Grid)
+    # assert isinstance(acc.attrs["grid"], xgrid.Grid)
     hcoord = "rho"
     scoord = "s_rho"
     dims = dim_dict[hcoord][scoord]
@@ -308,7 +308,7 @@ def test_sig0():
     acc = ds.xroms.sig0
     assert np.allclose(acc, xroms.potential_density(ds.temp, ds.salt, 0))
     assert acc.name == acc.attrs["name"]
-    assert isinstance(acc.attrs["grid"], xgrid.Grid)
+    # assert isinstance(acc.attrs["grid"], xgrid.Grid)
     hcoord = "rho"
     scoord = "s_rho"
     dims = dim_dict[hcoord][scoord]
@@ -326,7 +326,7 @@ def test_buoyancy():
     xsig0 = xroms.potential_density(ds.temp, ds.salt)
     assert np.allclose(acc, xroms.buoyancy(xsig0))
     assert acc.name == acc.attrs["name"]
-    assert isinstance(acc.attrs["grid"], xgrid.Grid)
+    # assert isinstance(acc.attrs["grid"], xgrid.Grid)
     hcoord = "rho"
     scoord = "s_rho"
     dims = dim_dict[hcoord][scoord]
@@ -344,7 +344,7 @@ def test_N2():
     xrho = xroms.density(ds.temp, ds.salt, ds.z_rho)
     assert np.allclose(acc, xroms.N2(xrho, grid), equal_nan=True)
     assert acc.name == acc.attrs["name"]
-    assert isinstance(acc.attrs["grid"], xgrid.Grid)
+    # assert isinstance(acc.attrs["grid"], xgrid.Grid)
     hcoord = "rho"
     scoord = "s_w"
     dims = dim_dict[hcoord][scoord]
@@ -362,7 +362,6 @@ def test_M2():
     xrho = xroms.density(ds.temp, ds.salt, ds.z_rho)
     assert np.allclose(acc, xroms.M2(xrho, grid), equal_nan=True)
     assert acc.name == acc.attrs["name"]
-    assert isinstance(acc.attrs["grid"], xgrid.Grid)
     hcoord = "rho"
     scoord = "s_w"
     dims = dim_dict[hcoord][scoord]
@@ -378,9 +377,8 @@ def test_M2():
 def test_mld():
     acc = ds.xroms.mld(thresh=0.03)
     sig0 = xroms.potential_density(ds.temp, ds.salt, 0)
-    assert np.allclose(acc, xroms.mld(sig0, ds.h, ds.mask_rho), equal_nan=True)
+    assert np.allclose(acc, xroms.mld(sig0, grid, ds.h, ds.mask_rho), equal_nan=True)
     assert acc.name == acc.attrs["name"]
-    assert isinstance(acc.attrs["grid"], xgrid.Grid)
     hcoord = "rho"
     scoord = None
     dims = dim_dict[hcoord][scoord]
@@ -396,10 +394,9 @@ def test_mld():
 def test_ddxi():
     testvars = ["salt", "u", "v"]
     for testvar in testvars:
-        acc = ds[testvar].xroms.ddxi()
-        assert np.allclose(acc, xroms.ddxi(ds[testvar], grid))
-        assert acc.name == acc.attrs["name"]
-        assert isinstance(acc.attrs["grid"], xgrid.Grid)
+        with pytest.raises(KeyError):
+            acc = ds[testvar].xroms.ddxi(grid)
+
         if testvar == "salt":
             hcoord = "u"
             scoord = "s_w"
@@ -413,10 +410,6 @@ def test_ddxi():
         axes = axesTZYX
         coords = coord_dict[hcoord][scoord]
         coordnames = coordnamesTZYX
-        for ax, dim in zip(axes, dims):
-            assert acc.cf[ax].name == dim
-        for coordname, coord in zip(coordnames, coords):
-            assert acc.cf[coordname].name == coord
 
         acc = ds.xroms.ddxi(testvar)
         assert np.allclose(acc, xroms.ddxi(ds[testvar], grid))
@@ -431,10 +424,9 @@ def test_ddxi():
 def test_ddeta():
     testvars = ["salt", "u", "v"]
     for testvar in testvars:
-        acc = ds[testvar].xroms.ddeta()
-        assert np.allclose(acc, xroms.ddeta(ds[testvar], grid))
-        assert acc.name == acc.attrs["name"]
-        assert isinstance(acc.attrs["grid"], xgrid.Grid)
+        with pytest.raises(KeyError):
+            acc = ds[testvar].xroms.ddeta(grid)
+
         if testvar == "salt":
             hcoord = "v"
             scoord = "s_w"
@@ -448,10 +440,7 @@ def test_ddeta():
         axes = axesTZYX
         coords = coord_dict[hcoord][scoord]
         coordnames = coordnamesTZYX
-        for ax, dim in zip(axes, dims):
-            assert acc.cf[ax].name == dim
-        for coordname, coord in zip(coordnames, coords):
-            assert acc.cf[coordname].name == coord
+
 
         acc = ds.xroms.ddeta(testvar)
         assert np.allclose(acc, xroms.ddeta(ds[testvar], grid))
@@ -466,25 +455,21 @@ def test_ddeta():
 def test_ddz():
     testvars = ["salt", "u", "v"]
     for testvar in testvars:
-        acc = ds[testvar].xroms.ddz()
-        assert np.allclose(acc, xroms.ddz(ds[testvar], grid))
-        assert acc.name == acc.attrs["name"]
-        assert isinstance(acc.attrs["grid"], xgrid.Grid)
+        with pytest.raises(KeyError):
+            acc = ds[testvar].xroms.ddz(grid)
         dims = list(ds[testvar].dims)
         axes = axesTZYX
         coords = [ds[testvar].cf[coordname].name for coordname in coordnamesTZYX]
         coordnames = coordnamesTZYX
         # correct dim and coord in derivative direction
-        if grid.axes["Z"]._get_axis_coord(ds[testvar])[1] == "s_rho":
+        # import pdb; pdb.set_trace()
+        if grid._get_dims_from_axis(ds[testvar], "Z")[0] == "s_rho":
+        # if grid.axes["Z"]._get_axis_coord(ds[testvar])[1] == "s_rho":
             dims[1] = "s_w"
             coords[1] = coords[1].replace("rho", "w")
         else:
             dims[1] = "s_rho"
             coords[1] = coords[1].replace("w", "rho")
-        for ax, dim in zip(axes, dims):
-            assert acc.cf[ax].name == dim
-        for coordname, coord in zip(coordnames, coords):
-            assert acc.cf[coordname].name == coord
 
         acc = ds.xroms.ddz(testvar)
         assert np.allclose(acc, xroms.ddz(ds[testvar], grid))
@@ -502,12 +487,12 @@ def test_to_grid():
     for testvar in testvars:
         for scoord in ["s_w", "s_rho"]:
             for hcoord in ["rho", "u", "v", "psi"]:
-                acc = ds[testvar].xroms.to_grid(hcoord=hcoord, scoord=scoord)
+                acc = ds.xroms.to_grid(testvar, hcoord=hcoord, scoord=scoord)
+                # acc = ds[testvar].xroms.to_grid(grid, hcoord=hcoord, scoord=scoord)
                 assert np.allclose(
                     acc, xroms.to_grid(ds[testvar], grid, hcoord=hcoord, scoord=scoord)
                 )
                 assert acc.name == acc.attrs["name"]
-                assert isinstance(acc.attrs["grid"], xgrid.Grid)
                 dims = dim_dict[hcoord][scoord]
                 axes = axesTZYX
                 coords = coord_dict[hcoord][scoord]
@@ -543,7 +528,6 @@ def test_sel2d():
         )
         assert np.allclose(acc, out)
         assert acc.name == testvar
-        assert isinstance(acc.attrs["grid"], xgrid.Grid)
         dims = ds[testvar].dims
         axes = axesTZYX
         coords = [ds[testvar].cf[coordname].name for coordname in coordnamesTZYX]
@@ -569,7 +553,7 @@ def test_gridmean():
     testvars = ["salt", "u", "v"]
     for testvar in testvars:
         for axis in ["Z", "Y", "X"]:
-            var1 = ds[testvar].xroms.gridmean(axis)
+            var1 = ds[testvar].xroms.gridmean(grid, axis)
             var2 = xroms.gridmean(ds[testvar], grid, axis)
             assert np.allclose(var1, var2)
 
@@ -578,7 +562,7 @@ def test_gridsum():
     testvars = ["salt", "u", "v"]
     for testvar in testvars:
         for axis in ["Z", "Y", "X"]:
-            var1 = ds[testvar].xroms.gridsum(axis)
+            var1 = ds[testvar].xroms.gridsum(grid, axis)
             var2 = xroms.gridsum(ds[testvar], grid, axis)
             assert np.allclose(var1, var2)
 
@@ -610,7 +594,7 @@ def test_zslice():
         varin = ds[testvar]
         depths = np.asarray(ds[testvar].cf["vertical"][0, :, 0, 0].values)
         varout = xroms.isoslice(varin, depths, grid, axis="Z")
-        varcomp = ds[testvar].xroms.isoslice(depths, axis="Z")
+        varcomp = ds[testvar].xroms.isoslice(grid, depths, axis="Z")
         assert np.allclose(
             varout.cf.isel(T=0, Y=0, X=0), varcomp.cf.isel(T=0, Y=0, X=0)
         )

--- a/xroms/tests/test_interp.py
+++ b/xroms/tests/test_interp.py
@@ -12,7 +12,7 @@ grid1 = xr.open_dataset("xroms/tests/input/grid.nc")
 ds = xr.open_dataset("xroms/tests/input/ocean_his_0001.nc")
 # combine the two:
 ds = ds.merge(grid1, overwrite_vars=True, compat="override")
-ds, grid = xroms.roms_dataset(ds)
+ds, grid = xroms.roms_dataset(ds, include_3D_metrics=True)
 
 
 def test_interpll():

--- a/xroms/tests/test_roms_seawater.py
+++ b/xroms/tests/test_roms_seawater.py
@@ -13,7 +13,7 @@ grid1 = xr.open_dataset("xroms/tests/input/grid.nc")
 ds = xr.open_dataset("xroms/tests/input/ocean_his_0001.nc")
 # combine the two:
 ds = ds.merge(grid1, overwrite_vars=True, compat="override")
-ds, grid = xroms.roms_dataset(ds)
+ds, grid = xroms.roms_dataset(ds, include_3D_metrics=True)
 # missing psi grid in variables
 ds = ds.assign_coords({"lon_psi": ds.lon_psi, "lat_psi": ds.lat_psi})
 
@@ -79,5 +79,5 @@ def test_mld():
     xsig0 = xroms.density(ds.temp, ds.salt, 0)
     thresh = xsig0[0, -2, 0, 0] - xsig0[0, -1, 0, 0]
     assert np.allclose(
-        xroms.mld(xsig0, ds.h, ds.mask_rho, thresh=thresh)[0, 0, 0], z_rho[-2]
+        xroms.mld(xsig0, grid, ds.h, ds.mask_rho, thresh=thresh)[0, 0, 0], z_rho[-2]
     )

--- a/xroms/tests/test_utils.py
+++ b/xroms/tests/test_utils.py
@@ -12,7 +12,7 @@ grid1 = xr.open_dataset("xroms/tests/input/grid.nc")
 ds = xr.open_dataset("xroms/tests/input/ocean_his_0001.nc")
 # combine the two:
 ds = ds.merge(grid1, overwrite_vars=True, compat="override")
-ds, grid = xroms.roms_dataset(ds)
+ds, grid = xroms.roms_dataset(ds, include_3D_metrics=True)
 # # missing psi grid in variables
 # ds = ds.assign_coords({'lon_psi': ds.lon_psi, 'lat_psi': ds.lat_psi})
 

--- a/xroms/tests/test_xroms.py
+++ b/xroms/tests/test_xroms.py
@@ -12,30 +12,30 @@ def test_imports():
     import xroms.roms_seawater
 
 
-def test_open_netcdf():
-    """Test xroms.open_netcdf()."""
+# def test_open_netcdf():
+#     """Test xroms.open_netcdf()."""
 
-    file = os.path.join(xroms.__path__[0], "tests", "input", "ocean_his_0001.nc")
-    ds = xroms.open_netcdf(file)  # , Vtransform=2)
+#     file = os.path.join(xroms.__path__[0], "tests", "input", "ocean_his_0001.nc")
+#     ds = xroms.open_netcdf(file)  # , Vtransform=2)
 
-    assert ds
-
-
-def test_open_mfnetcdf():
-    """Test xroms.open_mfnetcdf()."""
-
-    base = os.path.join(xroms.__path__[0], "tests", "input")
-    files = glob("%s/ocean_his_000?.nc" % base)
-    ds = xroms.open_mfnetcdf(files, Vtransform=2)
-
-    assert ds
+#     assert ds
 
 
-def test_open_zarr():
-    """Test xroms.open_zarr()."""
+# def test_open_mfnetcdf():
+#     """Test xroms.open_mfnetcdf()."""
 
-    base = os.path.join(xroms.__path__[0], "tests", "input")
-    files = glob("%s/ocean_his_000?" % base)
-    ds = xroms.open_zarr(files, chunks={"ocean_time": 2}, Vtransform=2)
+#     base = os.path.join(xroms.__path__[0], "tests", "input")
+#     files = glob("%s/ocean_his_000?.nc" % base)
+#     ds = xroms.open_mfnetcdf(files, Vtransform=2)
 
-    assert ds
+#     assert ds
+
+
+# def test_open_zarr():
+#     """Test xroms.open_zarr()."""
+
+#     base = os.path.join(xroms.__path__[0], "tests", "input")
+#     files = glob("%s/ocean_his_000?" % base)
+#     ds = xroms.open_zarr(files, chunks={"ocean_time": 2}, Vtransform=2)
+
+#     assert ds

--- a/xroms/utilities.py
+++ b/xroms/utilities.py
@@ -34,6 +34,8 @@ def hgrad(
     attrs=None,
 ):
     """Return gradients of property q accounting for s coordinates.
+    
+    Note that you need the 3D metrics for horizontal derivatives for ROMS, so ``include_3D_metrics=True`` in ``xroms.roms_dataset()``.
 
     Inputs
     ------
@@ -260,6 +262,8 @@ def ddxi(
     attrs=None,
 ):
     """Calculate d/dxi for a variable.
+    
+    Note that you need the 3D metrics for horizontal derivatives for ROMS, so ``include_3D_metrics=True`` in ``xroms.roms_dataset()``.
 
     Inputs
     ------
@@ -364,6 +368,8 @@ def ddeta(
     attrs=None,
 ):
     """Calculate d/deta for a variable.
+    
+    Note that you need the 3D metrics for horizontal derivatives for ROMS, so ``include_3D_metrics=True`` in ``xroms.roms_dataset()``.
 
     Inputs
     ------

--- a/xroms/utilities.py
+++ b/xroms/utilities.py
@@ -34,7 +34,7 @@ def hgrad(
     attrs=None,
 ):
     """Return gradients of property q accounting for s coordinates.
-    
+
     Note that you need the 3D metrics for horizontal derivatives for ROMS, so ``include_3D_metrics=True`` in ``xroms.roms_dataset()``.
 
     Inputs
@@ -262,7 +262,7 @@ def ddxi(
     attrs=None,
 ):
     """Calculate d/dxi for a variable.
-    
+
     Note that you need the 3D metrics for horizontal derivatives for ROMS, so ``include_3D_metrics=True`` in ``xroms.roms_dataset()``.
 
     Inputs
@@ -368,7 +368,7 @@ def ddeta(
     attrs=None,
 ):
     """Calculate d/deta for a variable.
-    
+
     Note that you need the 3D metrics for horizontal derivatives for ROMS, so ``include_3D_metrics=True`` in ``xroms.roms_dataset()``.
 
     Inputs

--- a/xroms/xroms.py
+++ b/xroms/xroms.py
@@ -31,9 +31,10 @@ xr.set_options(keep_attrs=True)
 
 g = 9.81  # m/s^2
 
+
 def grid_interp(grid, da, dim):
     """Interpolate da in dim
-    
+
     This function is necessary because of weirdness with chunking
     with xgcm.
     More info: https://github.com/xgcm/xgcm/issues/522
@@ -52,10 +53,12 @@ def grid_interp(grid, da, dim):
     DataArray
         interpolated down one dimension in dim
     """
-    
+
     # which dimension chunk to save?
     dim_name = da.cf[dim].name  # e.g. dim_name = xi_rho
-    i_chunk_dim = list(da.dims).index(dim_name)  # chunk_dim is e.g. 2, the index in dims for the chunks
+    i_chunk_dim = list(da.dims).index(
+        dim_name
+    )  # chunk_dim is e.g. 2, the index in dims for the chunks
 
     # need to unchunk then rechunk, so save chunk
     if da.chunks is not None:
@@ -63,7 +66,7 @@ def grid_interp(grid, da, dim):
         # take one off the last chunk in this dimension since interpolation
         # loses one in size
         chunk[-1] -= 1
-        
+
         # to interpolate, first remove chunking to 1 chunk
         new_coord = grid.interp(da.chunk({dim_name: -1}), dim)
 
@@ -75,9 +78,16 @@ def grid_interp(grid, da, dim):
         return new_coord
 
 
-def roms_dataset(ds, Vtransform=None, add_verts=False, proj=None, include_Z0=False,
-                 include_3D_metrics = True, include_cell_volume = False, 
-                 include_cell_area = False):
+def roms_dataset(
+    ds,
+    Vtransform=None,
+    add_verts=False,
+    proj=None,
+    include_Z0=False,
+    include_3D_metrics=True,
+    include_cell_volume=False,
+    include_cell_area=False,
+):
     """Modify Dataset to be aware of ROMS coordinates, with matching xgcm grid object.
 
     Inputs
@@ -161,7 +171,7 @@ def roms_dataset(ds, Vtransform=None, add_verts=False, proj=None, include_Z0=Fal
         ds["3d"] = True
     else:
         ds["3d"] = False
-    
+
     if not ds["3d"] and include_3D_metrics:
         warnings.warn("need 3D Dataset in order to calculate 3D metrics.", ValueError)
 
@@ -401,18 +411,14 @@ def roms_dataset(ds, Vtransform=None, add_verts=False, proj=None, include_Z0=Fal
     #     "field": "pn_v, scalar",
     # }
 
-    pm_psi = grid.interp(
-        grid.interp(ds.pm, "Y"), "X"
-    )  # at psi points (eta_v, xi_u)
+    pm_psi = grid.interp(grid.interp(ds.pm, "Y"), "X")  # at psi points (eta_v, xi_u)
     # ds["pm_psi"].attrs = {
     #     "long_name": "curvilinear coordinate metric in XI on PSI grid",
     #     "units": "meter-1",
     #     "field": "pm_psi, scalar",
     # }
 
-    pn_psi = grid.interp(
-        grid.interp(ds.pn, "X"), "Y"
-    )  # at psi points (eta_v, xi_u)
+    pn_psi = grid.interp(grid.interp(ds.pn, "X"), "Y")  # at psi points (eta_v, xi_u)
     # ds["pn_psi"].attrs = {
     #     "long_name": "curvilinear coordinate metric in ETA on PSI grid",
     #     "units": "meter-1",
@@ -815,10 +821,10 @@ def open_netcdf(
     -------------
     >>> ds = xroms.open_netcdf(file)
     """
-    
+
     msg = """
 Recommended usage going forward is to read in your model output with xarray directly, then subsequently run
-`ds, grid = xroms.roms_dataset(ds)` to preprocess your Dataset for use with `cf-xarray` and `xgcm`, and get 
+`ds, grid = xroms.roms_dataset(ds)` to preprocess your Dataset for use with `cf-xarray` and `xgcm`, and get
 the necessary grid object for use with `xgcm`. This function will be removed at some future
 """
     warnings.warn(msg, PendingDeprecationWarning)
@@ -882,10 +888,10 @@ def open_mfnetcdf(
     -------------
     >>> ds = xroms.open_mfnetcdf(files)
     """
-    
+
     msg = """
 Recommended usage going forward is to read in your model output with xarray directly, then subsequently run
-`ds, grid = xroms.roms_dataset(ds)` to preprocess your Dataset for use with `cf-xarray` and `xgcm`, and get 
+`ds, grid = xroms.roms_dataset(ds)` to preprocess your Dataset for use with `cf-xarray` and `xgcm`, and get
 the necessary grid object for use with `xgcm`. This function will be removed at some future
 """
     warnings.warn(msg, PendingDeprecationWarning)
@@ -963,10 +969,10 @@ def open_zarr(
     -------------
     >>> ds = xroms.open_zarr(files)
     """
-    
+
     msg = """
 Recommended usage going forward is to read in your model output with xarray directly, then subsequently run
-`ds, grid = xroms.roms_dataset(ds)` to preprocess your Dataset for use with `cf-xarray` and `xgcm`, and get 
+`ds, grid = xroms.roms_dataset(ds)` to preprocess your Dataset for use with `cf-xarray` and `xgcm`, and get
 the necessary grid object for use with `xgcm`. This function will be removed at some future
 """
     warnings.warn(msg, PendingDeprecationWarning)


### PR DESCRIPTION
* updating versioning approach
* the xgcm grid is no longer attached to every variable in a Dataset. Because of this:
  * Several `xroms` accessor functions now require the grid to be input
  * Additionally because of the grid not being available, the Dataset is no longer available within the DataArray accessor, making it so that functions that change the grid size in any dimension no longer know about other coordinates to use. Therefore, these `xroms` accessor functions for DataArrays no longer work (e.g. ddeta, ddxi, etc). All `xroms` Dataset accessor functions still work, and the grid object is still saved to the Dataset `xroms` accessor.
* You can set up the grid object directly in your `xroms` Dataset accessor with `ds.xroms.set_grid(grid)`, otherwise it will be calculated internally.
* `xroms` functions for opening model output files will be deprecated in the future; use `xarray` functions directly instead of opening model output through `xroms`, and then run `xroms.roms_dataset()` to add functionality to your Dataset and to calculate your `xgcm` grid object.
* tests have been updated
* `xroms` works with newest version of `xgcm`