### PR TITLE
Fix boundaries

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,6 +10,7 @@ dependencies:
    - cmocean
    - dask
    - esmf==8.4.1  # https://github.com/pangeo-data/xESMF/issues/246
+   - esmpy=>8.5.0 # https://github.com/esmf-org/esmf/issues/140
    - matplotlib-base
    - netcdf4
    - numpy <1.24  # https://github.com/numba/numba/issues/8615#issuecomment-1360792615

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,7 +9,7 @@ dependencies:
    - cf_xarray
    - cmocean
    - dask
-   - esmf==8.4.1  # https://github.com/pangeo-data/xESMF/issues/246
+   - esmf #==8.4.1  # https://github.com/pangeo-data/xESMF/issues/246
    - esmpy=>8.5.0 # https://github.com/esmf-org/esmf/issues/140
    - matplotlib-base
    - netcdf4

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,6 +1,6 @@
 # What's New
 
-## v0.6.1 (October 25, 2024)
+## v0.6.1 (October 28, 2024)
 * Correction in a few built-in calculations of u/v grid to rho-grid interpolations of u and v velocities (currently `speed` and `_uv2eastnorth`). In these cases, we need to fill nans with zeros so that the masked locations in the velocity fields are not fully brought forward into the rho mask but are instead interpolated over. By making them 0, they are calculated into the mask\_rho positions by combining them with neighboring cells. If this wasn't done, the fact that they are masked would supersede the neighboring cells and they would be masked in mask\_rho. This needs to be done anytime the velocities are moved from their native grids to the rho or other grids to preserve their locations around masked cells.
 
 ## v0.6.0 (February 9, 2024)

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,5 +1,8 @@
 # What's New
 
+## v0.6.1 (October 25, 2024)
+* Correction in a few built-in calculations of u/v grid to rho-grid interpolations of u and v velocities (currently `speed` and `_uv2eastnorth`). In these cases, we need to fill nans with zeros so that the masked locations in the velocity fields are not fully brought forward into the rho mask but are instead interpolated over. By making them 0, they are calculated into the mask\_rho positions by combining them with neighboring cells. If this wasn't done, the fact that they are masked would supersede the neighboring cells and they would be masked in mask\_rho. This needs to be done anytime the velocities are moved from their native grids to the rho or other grids to preserve their locations around masked cells.
+
 ## v0.6.0 (February 9, 2024)
 * fixed error in `derived.py`'s `uv_geostrophic` function after being pointed out by @ak11283
 * updated docs so mostly well-formatted and working

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   # # https://github.com/h5py/h5py/issues/1880
   # # https://github.com/conda-forge/h5py-feedstock/issues/92
   # - h5py < 3.2
+  - esmpy>=8.5.0  # https://github.com/esmf-org/esmf/issues/140
   - matplotlib-base
   - netcdf4
   - numpy <1.24  # https://github.com/numba/numba/issues/8615#issuecomment-1360792615


### PR DESCRIPTION
Correction in a few built-in calculations of u/v grid to rho-grid interpolations of u and v velocities (currently `speed` and `_uv2eastnorth`). In these cases, we need to fill nans with zeros so that the masked locations in the velocity fields are not fully brought forward into the rho mask but are instead interpolated over. By making them 0, they are calculated into the mask\_rho positions by combining them with neighboring cells. If this wasn't done, the fact that they are masked would supersede the neighboring cells and they would be masked in mask\_rho. This needs to be done anytime the velocities are moved from their native grids to the rho or other grids to preserve their locations around masked cells.